### PR TITLE
dodan db port v Repo povezavo

### DIFF
--- a/Database.py
+++ b/Database.py
@@ -11,7 +11,9 @@ from re import sub, findall
 from datetime import date
 from pandas import DataFrame
 from dataclasses import fields
+import os
 
+DB_PORT = os.environ.get('POSTGRES_PORT', 5432)
 
 # Ustvarimo generično TypeVar spremenljivko. Dovolimo le naše entitene, ki jih imamo tudi v bazi
 # kot njene vrednosti. Ko dodamo novo entiteno, jo moramo dodati tudi v to spremenljivko.
@@ -27,7 +29,7 @@ T = TypeVar(
 class Repo:
 
     def __init__(self):
-        self.conn = psycopg2.connect(database=auth.db, host=auth.host, user=auth.user, password=auth.password, port=5432)
+        self.conn = psycopg2.connect(database=auth.db, host=auth.host, user=auth.user, password=auth.password, port=DB_PORT)
         self.cur = self.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
 
 

--- a/trgovanje.py
+++ b/trgovanje.py
@@ -25,11 +25,11 @@ graf = Graf()
 # Privzete nastavitve
 SERVER_PORT = os.environ.get('BOTTLE_PORT', 8080)
 RELOADER = os.environ.get('BOTTLE_RELOADER', True)
-DB_PORT = os.environ.get('POSTGRES_PORT', 5432)
+
 
 # Priklop na bazo
-conn = psycopg2.connect(database=db, host=host, user=user, password=password, port=DB_PORT)
-cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor) 
+# conn = psycopg2.connect(database=db, host=host, user=user, password=password, port=DB_PORT)
+# cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor) 
 
 
 @get('/static/<filename:path>')


### PR DESCRIPTION
Za zagon v binderju je potrebno uporabit port 443 (privzet https port) za dostop do postgresql baze. Port 5432 je očitno blokiran v binderju in ni na voljo.
